### PR TITLE
[8.x] Added array doc block for aggregate functions

### DIFF
--- a/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/Illuminate/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -442,7 +442,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the max of the relation's column.
      *
-     * @param  string  $relation
+     * @param  string|array  $relation
      * @param  string  $column
      * @return $this
      */
@@ -454,7 +454,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the min of the relation's column.
      *
-     * @param  string  $relation
+     * @param  string|array  $relation
      * @param  string  $column
      * @return $this
      */
@@ -466,7 +466,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the sum of the relation's column.
      *
-     * @param  string  $relation
+     * @param  string|array  $relation
      * @param  string  $column
      * @return $this
      */
@@ -478,7 +478,7 @@ trait QueriesRelationships
     /**
      * Add subselect queries to include the average of the relation's column.
      *
-     * @param  string  $relation
+     * @param  string|array  $relation
      * @param  string  $column
      * @return $this
      */


### PR DESCRIPTION
This helps the [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) package and all IDE plugins that depends on it.

If preferred I can push `mixed` instead of `string|array`